### PR TITLE
Typos in documentation

### DIFF
--- a/doc_src/docs/user_guide/loading_texts.md
+++ b/doc_src/docs/user_guide/loading_texts.md
@@ -8,7 +8,7 @@ This module contains three main components:
 2. `ParallelLoader`: An optimized version of `Loader` for loading large numbers of files using concurrent processing.
 3. `DataLoader`: A specialized loader for structured data files such as CSVs, JSON, or Excel files.
 
-All loaders inherit from a common `BaseLoader` class that provides a bluepring and common features for other classes. It includes methods for loading files, processing text, and handling errors. If neither of the provided classes can accommodate the content you are trying to load, you can build a custom loader that derives from this class.
+All loaders inherit from a common `BaseLoader` class that provides a blueprint and common features for other classes. It includes methods for loading files, processing text, and handling errors. If neither of the provided classes can accommodate the content you are trying to load, you can build a custom loader that derives from this class.
 
 All loaders built on `BaseLoader` have the following attributes for storing loaded data:
 

--- a/doc_src/docs/user_guide/preprocessing_steps.md
+++ b/doc_src/docs/user_guide/preprocessing_steps.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Before you begin to analyze your documents, you may which to perform a number of preprocessing procedures on them to prepare them for analysis.
+Before you begin to analyze your documents, you may wish to perform a number of preprocessing procedures on them to prepare them for analysis.
 
 Lexos offers four methods of preprocessing:
 
-1. [Scrubbing](scrubbing_texts.md) (also called text cleaning): Transformation of the raw text string for of your data
+1. [Scrubbing](scrubbing_texts.md) (also called text cleaning): Transformation of the raw text string for your data
 2. [Tokenization](tokenizing_texts.md): Split your text into countable tokens, optionally with language-specific rules that may also annotate tokens with linguistic metadata.
 3. [Cutting](cutting_documents.md): Split your text into smaller texts (or perform the reverse by merging smaller texts). Boundaries for cutting can be based on a variety of string or token patterns, as well as structural divisions (milestones) in your texts.
 4. [Filtering](filtering_documents.md): Remove tokens from pre-tokenized texts based on token annotations.

--- a/doc_src/docs/user_guide/scrubber/normalize.md
+++ b/doc_src/docs/user_guide/scrubber/normalize.md
@@ -30,7 +30,7 @@ print(normalized_text)
 
 ## Example Using in a Pipeline
 
-The example below shows how the components can used in a Scrubber pipeline.
+The example below shows how the components can be used in a Scrubber pipeline.
 
 ```python
 from lexos.scrubber import Scrubber


### PR DESCRIPTION
Fixed bluepring to blueprint, added and deleted necessary words in pre-processing steps, and fixed the normalize section to "can be" instead of "The example below shows how the components can used in a Scrubber pipeline."